### PR TITLE
Babel no longer plays with CommonJS modules (aka enable Tree Shaking!)

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,7 @@
 {
   "presets": [
-    "es2015",
+    ["es2015", { "modules": false }],
     "react"
   ],
+  
 }

--- a/server.js
+++ b/server.js
@@ -1,11 +1,11 @@
 /* eslint no-console: 0 */
 /* eslint import/no-extraneous-dependencies: ["error", { "devDependencies": true  }] */
-import path from 'path';
-import express from 'express';
-import webpack from 'webpack';
-import webpackMiddleware from 'webpack-dev-middleware';
-import webpackHotMiddleware from 'webpack-hot-middleware';
-import config from './webpack.config';
+const path = require('path');
+const express = require('express');
+const webpack = require('webpack');
+const webpackMiddleware = require('webpack-dev-middleware');
+const webpackHotMiddleware = require('webpack-hot-middleware');
+const config = require('./webpack.config');
 
 const isProduction = process.env.NODE_ENV === 'production';
 const port = isProduction ? process.env.PORT : 3000;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,8 +1,8 @@
 /* eslint import/no-extraneous-dependencies: ["error", { "devDependencies": true  }] */
-import path from 'path';
-import webpack from 'webpack';
-import HtmlWebpackPlugin from 'html-webpack-plugin';
-import nib from 'nib';
+const path = require('path');
+const webpack = require('webpack');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const nib = require('nib');
 
 module.exports = {
 


### PR DESCRIPTION
## PR Overview
* Babel no longer converts our ES2015 modules into CommonJS modules, so our WebPack 2 setup is now capable of tree shaking.
* The change is straightforward:
  * in `.babelrc`, we specify that the `es2015` preset mustn't use modules transmorphications.
  * in every file that uses the `import` command, replace that with `require`.
* Since the end goal of this PR is to enable automagic tree-shaking with our Webpack 2 setup, I've replicated this PR with a way to test that unused/un-imported functions. Check out PR #7

### References
* Webpack 2 and tree-shaking: https://webpack.js.org/guides/tree-shaking/
* How to configure Webpack 2 to enable tree-shaking (i.e. get rid of CommonJS modules): https://medium.com/modus-create-front-end-development/webpack-2-tree-shaking-configuration-9f1de90f3233
* Note that in the previous article, the author suggests replacing `es2015` with `es2015-native-modules`. Current research shows that `es2015-native-modules` has in turn been deprecated, as the ES2015 preset can natively disable CommonJS transmogrifications by using `{ "modules": false }`

### Status
Ready for review - assigning @wgranger as primary reviewer, and tagging @srallen and @simoneduca for feedback.