### PR TITLE
Re-enable Tree Shaking

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
   "presets": [
-    "es2015",
+    ["es2015", { "modules": false }],
     "react"
   ]
 }

--- a/server.js
+++ b/server.js
@@ -6,7 +6,7 @@ const webpack = require('webpack');
 const webpackMiddleware = require('webpack-dev-middleware');
 const webpackHotMiddleware = require('webpack-hot-middleware');
 const config = require('./webpack.config');
-import DashboardPlugin from 'webpack-dashboard/plugin';
+const DashboardPlugin = require('webpack-dashboard/plugin');
 
 const isProduction = process.env.NODE_ENV === 'production';
 const port = isProduction ? process.env.PORT : 3000;


### PR DESCRIPTION
## PR Review
* Quick fix: this re-enables Webpack 2's inherent tree-shaking capabilities, first introduced in PR #8 and patched out in PR #9 
* There are two parts to this:
  * First, all `import` statements in `server.js` and `webpack.config` need to be replaced with `require()`
  * Second - and this isn't as apparent - all bundled code will only use functions/code that are explicitly imported and used in the source.

### Status
Ready for review. Compiles (`npm start`), tests and builds correctly on OSX. 