### PR TITLE
Setup multiple babel env

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,10 @@
 {
   "env": {
     "development": {
-      "presets": ["es2015", "react"]
+      "presets": [
+        ["es2015", { "modules": false }],
+        "react"
+      ]
     },
     "production": {
       "presets": [

--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,13 @@
 {
-  "presets": [
-    ["es2015", { "modules": false }],
-    "react"
-  ]
+  "env": {
+    "dev": {
+      "presets": [
+        ["es2015", { "modules": false }],
+        "react"
+      ]
+    },
+    "test": {
+      "presets": ["es2015", "react"]
+    }
+  }
 }

--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,9 @@
 {
   "env": {
-    "dev": {
+    "development": {
+      "presets": ["es2015", "react"]
+    },
+    "production": {
       "presets": [
         ["es2015", { "modules": false }],
         "react"

--- a/.babelrc
+++ b/.babelrc
@@ -1,10 +1,7 @@
 {
   "env": {
     "development": {
-      "presets": [
-        ["es2015", { "modules": false }],
-        "react"
-      ]
+      "presets": ["es2015", "react"]
     },
     "production": {
       "presets": [

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/zooniverse/zoo-reduxify"
   },
   "scripts": {
-    "start": "webpack-dashboard -- babel-node server.js",
+    "start": "BABEL_ENV=dev webpack-dashboard -- babel-node server.js",
     "test": "NODE_ENV=development BABEL_ENV=test mocha $(find src -name *.spec.jsx) --compilers js:babel-core/register || true",
     "eslint": "eslint .",
     "build": "webpack --config webpack.production.config.js -p"

--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
     "url": "https://github.com/zooniverse/zoo-reduxify"
   },
   "scripts": {
-    "start": "BABEL_ENV=dev webpack-dashboard -- babel-node server.js",
+    "start": "BABEL_ENV=development webpack-dashboard -- babel-node server.js",
     "test": "NODE_ENV=development BABEL_ENV=test mocha $(find src -name *.spec.jsx) --compilers js:babel-core/register || true",
     "eslint": "eslint .",
-    "build": "webpack --config webpack.production.config.js -p"
+    "build": "BABEL_ENV=production webpack --config webpack.production.config.js -p"
   },
   "author": "Zooniverse",
   "license": "Apache-2.0",


### PR DESCRIPTION
Use the `env` option in `babelrc` to disable Webpack 2 tree-shaking feature where it isn't needed, i.e. development and testing.