### PR TITLE
Remove bitHound score from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![bitHound Score](https://www.bithound.io/github/Granze/react-starterify/badges/score.svg)](https://www.bithound.io/github/zooniverse/zoo-react-starterify/master)
-
 # Zooniverse Reduxify
 
 A minimal Redux application starter kit, based on [Zooniverse React Starterify](https://github.com/zooniverse/zoo-react-starterify).


### PR DESCRIPTION
## PR Overview
This PR removes the bitHound score from the Readme page, because [bitHound](http://bithound.io/) has shut down. 

Also: was this repo using the badge for Granze's React Starterify repo instead of our Zooniverse repo?