### PR TITLE
Update PJC to 2.11.2 for compatibility with new Panoptes updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/zooniverse/zoo-reduxify",
   "dependencies": {
     "history": "~4.6.3",
-    "panoptes-client": "~2.11.0",
+    "panoptes-client": "~2.11.2",
     "prop-types": "~15.5.10",
     "react": "~15.6.1",
     "react-dom": "~15.6.1",


### PR DESCRIPTION
## PR Overview
This PR updates `panoptes-client` to v2.11.2, which is necessary for compatibility with one of Panoptes's upcoming updates. See https://github.com/zooniverse/panoptes-javascript-client/pull/103 for further details.

### Status
Merging.